### PR TITLE
Feature/table quoting

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -123,10 +123,7 @@ func (a *Adapter) tableIdentifier() pgx.Identifier {
 }
 
 func (a *Adapter) schemaTable() string {
-	if a.schema != "" {
-		return fmt.Sprintf("%q.%s", a.schema, a.tableName)
-	}
-	return a.tableName
+	return a.tableIdentifier().Sanitize()
 }
 
 // LoadPolicy loads policy from database.
@@ -480,7 +477,7 @@ func createDatabase(dbname string, arg interface{}) (*pgxpool.Pool, error) {
 	rows.Close()
 
 	if createdb {
-		_, err = conn.Exec(ctx, "CREATE DATABASE "+dbname)
+		_, err = conn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{dbname}.Sanitize())
 		if err != nil {
 			return nil, err
 		}

--- a/adapter.go
+++ b/adapter.go
@@ -219,8 +219,8 @@ func (a *Adapter) SavePolicy(model model.Model) error {
 func (a *Adapter) insertPolicyStmt() string {
 	return fmt.Sprintf(`
 		INSERT INTO %s (id, p_type, v0, v1, v2, v3, v4, v5)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT ON CONSTRAINT %s_pkey DO NOTHING
-	`, a.schemaTable(), a.tableName)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (id) DO NOTHING
+	`, a.schemaTable())
 }
 
 // AddPolicy adds a policy rule to the storage.

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -396,7 +396,7 @@ func TestCustomSchema(t *testing.T) {
 	connStr := os.Getenv("PG_CONN")
 	require.NotEmpty(t, connStr, "must run with non-empty PG_CONN")
 	defer dropDB(t, "test_pgxadapter")
-	a, err := NewAdapter(connStr, WithDatabase("test_pgxadapter"), WithSchema("My_Schema"))
+	a, err := NewAdapter(connStr, WithDatabase("TestPgxAdapter"), WithSchema("MySchema"), WithTableName("TestCasbinRules"))
 	require.NoError(t, err)
 	defer a.Close()
 


### PR DESCRIPTION
Here is a fix to handle proper quoting of `dbName`, `schema`, and `tableName`. 

Regarding backward compatibility:

- `WithDatabase("TestPgxAdapter")` failed in the current code. With this PR it works. Should not present a BC issue.
- `WithSchema("MySchema")` worked previously, but the quoting is not robust
- `WithTableName("TestCasbinRules")` worked for a subset of the API. _It failed the test suite_.

There isn't an excellent way to prevent the potential to break someone's code that is using `WithTableName("TestCasbinRules")` but only accessing the part of the API that works with it.

The following API's failed with `WithTableName("TestCasbinRules")`
- `SavePolicy()`

**Additional thoughts on Backwards Compatibility**:
If your code is using `WithTableName("TestCasbinRules")`, the actual table name is `testcasbinrules`. With this change, it will suddenly try accessing `TestCasbinRules`, which will not exist and depending on your settings may be created.

Closes #8 