### PR TITLE
Fix for detecting table when we don't know what schema it is in

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/casbin/casbin/v2 v2.56.0
+	github.com/jackc/pgconn v1.10.0
 	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/mmcloughlin/meow v0.0.0-20200201185800-3501c7c05d21


### PR DESCRIPTION
This fixes the situation where the table is not in the public schema due to the default search path. So by querying for the table, we can let the database find the table. I tried to make the query lightweight and one that will return a row even when the table is empty.

When the table is not found, it returns an error and that is the happy path.